### PR TITLE
Bumped gradle

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,7 +16,7 @@ object Versions {
     const val mockito_all = "1.10.19"
     const val dexmaker = "2.2.0"
     const val timber = "4.7.0"
-    const val android_gradle_plugin = "3.5.0-alpha04"
+    const val android_gradle_plugin = "3.5.2"
     const val hamcrest = "1.3"
     const val kotlin = "1.3.21"
     const val work = "1.0.0-alpha01"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Bumped gradle to make project build in modern AS versions

In AS 3.5:
![Skärmavbild 2019-12-20 kl  11 27 45](https://user-images.githubusercontent.com/47774888/71248719-dbfb7380-231b-11ea-91e9-1afbd5e780d7.png)
